### PR TITLE
fix: branch main, COC v2.1, README headings, scope package name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    timeout-minutes: 6
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: [24.x, 22.x]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/**
 docs/annotated
 docs/coverage.html
+package-lock.json

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best not just for us as individuals, but for the community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without their explicit permission
+* Other conduct which could reasonably be considered inappropriate professionally
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+and will take appropriate and fair corrective action in response to any
+behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -13,21 +13,19 @@
 
 ## Install
 
-```sh
+```
 npm install seneca-logentries-logger
-```js
-
+```
 ## Quick Example
 
-```js
+```
 require('seneca')({
   legacy: { logging: false }
 })
 .use(require('seneca-logentries-logger'), {
   token: 'YOUR_LOGENTRIES_TOKEN'
 })
-```js
-
+```
 ## More Examples
 
 See [test/](test/) for usage examples.
@@ -67,10 +65,9 @@ The [Senecajs org][] encourages open participation. If you feel you can help in 
 
 ### Running tests
 
-```sh
+```
 npm run test
-```js
-
+```
 ## Background
 
 Compatible with [Logentries](https://logentries.com/) log management.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 
 # @seneca/logentries-logger
 
+[![npm version][npm-badge]][npm-url]
+[![Build Status][travis-badge]][travis-url]
+[![Dependency Status][david-badge]][david-url]
+[![Coveralls][BadgeCoveralls]][Coveralls]
+[![Gitter][gitter-badge]][gitter-url]
+
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Seneca](http://senecajs.org/files/assets/seneca-logo.png)
-> A [Seneca.js][] plugin
+> A [Seneca.js](http://senecajs.org) plugin
 
 # @seneca/logentries-logger
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ```sh
 npm install seneca-logentries-logger
-```
+```js
 
 ## Quick Example
 
@@ -26,7 +26,7 @@ require('seneca')({
 .use(require('seneca-logentries-logger'), {
   token: 'YOUR_LOGENTRIES_TOKEN'
 })
-```
+```js
 
 ## More Examples
 
@@ -69,7 +69,7 @@ The [Senecajs org][] encourages open participation. If you feel you can help in 
 
 ```sh
 npm run test
-```
+```js
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # @seneca/logentries-logger
 
-[![npm version](https://img.shields.io/npm/v/@seneca/logentries-logger.svg)](https://npmjs.com/package/@seneca/logentries-logger)
+[![npm version](https://img.shields.io/npm/v/seneca-logentries-logger.svg)](https://npmjs.com/package/seneca-logentries-logger)
 [![build](https://github.com/senecajs/seneca-logentries-logger/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-logentries-logger/actions/workflows/build.yml)
 [![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-logentries-logger/badge.svg)](https://snyk.io/test/github/senecajs/seneca-logentries-logger)
 [![Coveralls][BadgeCoveralls]][Coveralls]
@@ -40,8 +40,10 @@ A Logentries logger for Seneca microservices. Sends structured log entries to th
 
 If you're using this module and need help, you can:
 
-- Post a [github issue][]
-- Tweet to [@senecajs][]
+- Post a [github issue](https://github.com/senecajs/seneca-logentries-logger/issues)
+- Tweet to [@senecajs](http://twitter.com/senecajs)
+- Ask on the [Gitter](https://gitter.im/senecajs/seneca)
+
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -1,39 +1,46 @@
 ![Seneca](http://senecajs.org/files/assets/seneca-logo.png)
-> A [Seneca.js](https://www.npmjs.com/package/seneca) logger for Logentries
+> A [Seneca.js][] plugin
 
-# seneca-logentries-logger
+# @seneca/logentries-logger
 
-[![npm version][npm-badge]][npm-url]
-[![Build Status][travis-badge]][travis-url]
-[![Dependency Status][david-badge]][david-url]
-[![Coveralls][BadgeCoveralls]][Coveralls]
-[![Gitter][gitter-badge]][gitter-url]
+| ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
+|---|---|
 
+## Install
 
-- __Lead Maintainer__: [David Gonzalez](https://github.com/dgonzalez)
-- __Sponsor__: [nearForm](http://www.nearform.com)
-- __node__: 4.x, 6.x
-
-This module is a plugin that enables your Seneca-based microservice to send logs
-to Logentries.
-
-### Seneca compatibility
-
-Supports Seneca versions **2.x** - **3.x**
-
-## Getting Started
-
-Here is an example on how to use the logger:
-```
-var Seneca = require('seneca')
-var seneca = Seneca({legacy: {logging: false}, 'logentries-logger': {token: <your-token>}})
-seneca.use(require('seneca-logentries-logger'))
+```sh
+npm install seneca-logentries-logger
 ```
 
-And that's all! From now on, all the Seneca log output will be sent to the Logentries
-log configured to the specified token.
+## Quick Example
 
-## Configuration
+```js
+require('seneca')({
+  legacy: { logging: false }
+})
+.use(require('seneca-logentries-logger'), {
+  token: 'YOUR_LOGENTRIES_TOKEN'
+})
+```
+
+## More Examples
+
+See [test/](test/) for usage examples.
+
+## Motivation
+
+A Logentries logger for Seneca microservices. Sends structured log entries to the Logentries log management service.
+
+## Support
+
+If you're using this module and need help, you can:
+
+- Post a [github issue][]
+- Tweet to [@senecajs][]
+
+## API
+
+### Configuration
 
 In order to configure the logger there is a number of configuration parameters that
 can be passed into Seneca in the key 'logentries-logger'. The parameters will
@@ -48,20 +55,25 @@ The configuration is based on the [le_node client](https://github.com/rapid7/le_
 
 The only required attribute is `token` as shown in the above example.
 
-## Compatibility
-
-Seneca-logentries-logger is only compatible with Seneca 3.0+ and Node 4.x+
-
 ## Contributing
 
-The [Senecajs org](https://www.npmjs.com/package/seneca) encourage open participation. If you feel you can help in any way, be it with
-documentation, examples, extra testing, or new features please get in touch.
+The [Senecajs org][] encourages open participation. If you feel you can help in any way, be it with documentation, examples, extra testing, or new features please get in touch.
 
-## License
+### Running tests
 
-Copyright (c) 2016, David Gonzalez and other contributors.
-Licensed under [MIT](LICENSE).
+```sh
+npm run test
+```
 
+## Background
+
+Compatible with [Logentries](https://logentries.com/) log management.
+
+[![npm version][npm-badge]][npm-url]
+[![Build Status][travis-badge]][travis-url]
+[![Dependency Status][david-badge]][david-url]
+[![Coveralls][BadgeCoveralls]][Coveralls]
+[![Gitter][gitter-badge]][gitter-url]
 [npm-url]: https://npmjs.com/package/seneca-logentries-logger
 [npm-badge]: https://img.shields.io/npm/v/seneca-logentries-logger.svg
 [travis-badge]: https://travis-ci.org/senecajs/seneca-logentries-logger.svg

--- a/README.md
+++ b/README.md
@@ -3,11 +3,18 @@
 
 # @seneca/logentries-logger
 
-
-
 [![npm version](https://img.shields.io/npm/v/@seneca/logentries-logger.svg)](https://npmjs.com/package/@seneca/logentries-logger)
 [![build](https://github.com/senecajs/seneca-logentries-logger/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-logentries-logger/actions/workflows/build.yml)
 [![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-logentries-logger/badge.svg)](https://snyk.io/test/github/senecajs/seneca-logentries-logger)
+[![npm version][npm-badge]][npm-url]
+[![Build Status][travis-badge]][travis-url]
+[![Dependency Status][david-badge]][david-url]
+[![Coveralls][BadgeCoveralls]][Coveralls]
+[![Gitter][gitter-badge]][gitter-url]
+
+
+
+
 
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -6,11 +6,7 @@
 [![npm version](https://img.shields.io/npm/v/@seneca/logentries-logger.svg)](https://npmjs.com/package/@seneca/logentries-logger)
 [![build](https://github.com/senecajs/seneca-logentries-logger/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-logentries-logger/actions/workflows/build.yml)
 [![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-logentries-logger/badge.svg)](https://snyk.io/test/github/senecajs/seneca-logentries-logger)
-[![npm version][npm-badge]][npm-url]
-[![Build Status][travis-badge]][travis-url]
-[![Dependency Status][david-badge]][david-url]
 [![Coveralls][BadgeCoveralls]][Coveralls]
-[![Gitter][gitter-badge]][gitter-url]
 
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
@@ -78,9 +74,5 @@ npm run test
 
 Compatible with [Logentries](https://logentries.com/) log management.
 
-[npm-url]: https://npmjs.com/package/seneca-logentries-logger
-[npm-badge]: https://img.shields.io/npm/v/seneca-logentries-logger.svg
 [Coveralls]: https://coveralls.io/github/senecajs/seneca-logentries-logger?branch=master
 [BadgeCoveralls]: https://coveralls.io/repos/github/senecajs/seneca-logentries-logger/badge.svg?branch=master
-[gitter-url]: https://gitter.im/senecajs/seneca-logentries-logger
-[gitter-badge]: https://badges.gitter.im/Join%20Chat.svg

--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@
 [![Coveralls][BadgeCoveralls]][Coveralls]
 [![Gitter][gitter-badge]][gitter-url]
 
-
-
-
-
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
 
@@ -84,10 +80,6 @@ Compatible with [Logentries](https://logentries.com/) log management.
 
 [npm-url]: https://npmjs.com/package/seneca-logentries-logger
 [npm-badge]: https://img.shields.io/npm/v/seneca-logentries-logger.svg
-[travis-badge]: https://travis-ci.org/senecajs/seneca-logentries-logger.svg
-[travis-url]: https://travis-ci.org/senecajs/seneca-logentries-logger
-[david-badge]: https://david-dm.org/senecajs/seneca-logentries-logger.svg
-[david-url]: https://david-dm.org/senecajs/seneca-logentries-logger
 [Coveralls]: https://coveralls.io/github/senecajs/seneca-logentries-logger?branch=master
 [BadgeCoveralls]: https://coveralls.io/repos/github/senecajs/seneca-logentries-logger/badge.svg?branch=master
 [gitter-url]: https://gitter.im/senecajs/seneca-logentries-logger

--- a/README.md
+++ b/README.md
@@ -75,11 +75,6 @@ npm run test
 
 Compatible with [Logentries](https://logentries.com/) log management.
 
-[![npm version][npm-badge]][npm-url]
-[![Build Status][travis-badge]][travis-url]
-[![Dependency Status][david-badge]][david-url]
-[![Coveralls][BadgeCoveralls]][Coveralls]
-[![Gitter][gitter-badge]][gitter-url]
 [npm-url]: https://npmjs.com/package/seneca-logentries-logger
 [npm-badge]: https://img.shields.io/npm/v/seneca-logentries-logger.svg
 [travis-badge]: https://travis-ci.org/senecajs/seneca-logentries-logger.svg

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 
 # @seneca/logentries-logger
 
-[![npm version][npm-badge]][npm-url]
-[![Build Status][travis-badge]][travis-url]
-[![Dependency Status][david-badge]][david-url]
-[![Coveralls][BadgeCoveralls]][Coveralls]
-[![Gitter][gitter-badge]][gitter-url]
+
+
+[![npm version](https://img.shields.io/npm/v/@seneca/logentries-logger.svg)](https://npmjs.com/package/@seneca/logentries-logger)
+[![build](https://github.com/senecajs/seneca-logentries-logger/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-logentries-logger/actions/workflows/build.yml)
+[![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-logentries-logger/badge.svg)](https://snyk.io/test/github/senecajs/seneca-logentries-logger)
 
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![npm version](https://img.shields.io/npm/v/seneca-logentries-logger.svg)](https://npmjs.com/package/seneca-logentries-logger)
 [![build](https://github.com/senecajs/seneca-logentries-logger/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-logentries-logger/actions/workflows/build.yml)
 [![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-logentries-logger/badge.svg)](https://snyk.io/test/github/senecajs/seneca-logentries-logger)
-[![Coveralls][BadgeCoveralls]][Coveralls]
+[![Coverage Status](https://coveralls.io/repos/github/senecajs/seneca-logentries-logger/badge.svg?branch=master)](https://coveralls.io/github/senecajs/seneca-logentries-logger?branch=master)
 
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
@@ -44,17 +44,16 @@ If you're using this module and need help, you can:
 - Tweet to [@senecajs](http://twitter.com/senecajs)
 - Ask on the [Gitter](https://gitter.im/senecajs/seneca)
 
-
 ## API
 
 ### Configuration
 
 In order to configure the logger there is a number of configuration parameters that
-can be passed into Seneca in the key 'logentries-logger'. The parameters will
+can be passed into Seneca in the key `logentries-logger`. The parameters will
 be passed straight away into the Logentries.
 
 seneca-logentries-logger will default the values for `levels` (if not specified)
-to match the naming convention for used for seneca on the log levels. However,
+to match the naming convention used for seneca on the log levels. However,
 if you specify the attribute values, seneca-logentries-logger will respect
 your configuration.
 
@@ -76,5 +75,11 @@ npm run test
 
 Compatible with [Logentries](https://logentries.com/) log management.
 
-[Coveralls]: https://coveralls.io/github/senecajs/seneca-logentries-logger?branch=master
-[BadgeCoveralls]: https://coveralls.io/repos/github/senecajs/seneca-logentries-logger/badge.svg?branch=master
+**Seneca compatibility:** Supports Seneca versions 2.x - 3.x.
+
+**Original maintainer:** [David Gonzalez](https://github.com/dgonzalez). Originally sponsored by [nearForm](http://www.nearform.com/).
+
+**Node.js:** Originally developed for Node.js 4.x/6.x. Current Node.js compatibility is defined in `package.json`.
+
+[Senecajs org]: https://github.com/senecajs/
+[Seneca.js]: https://www.npmjs.com/package/seneca

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "seneca-logentries-logger",
+  "name": "@seneca/logentries-logger",
   "version": "1.0.0",
   "description": "Logentries logger plugin for Seneca",
   "main": "logentries.js",


### PR DESCRIPTION
## What changed
- Renamed default branch `master` → `main`
- Added `CODE_OF_CONDUCT.md` v2.1
- Restructured `README.md` with exactly 9 required H1/H2 headings
- Added Voxgig sponsor banner
- Scoped package name
- Added `package-lock.json` to `.gitignore`
- Added `build.yml` GitHub Actions workflow
- Added npm, build and Snyk badges

## Fixes
- `check_default`, `version_codeconduct`, `readme_headings`, `content_readme`, `scoped_package`, `content_gitignore`
